### PR TITLE
Add Prometheus metrics instrumentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM golang:1.26 as builder
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION=dev
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -17,13 +18,14 @@ COPY apis/ apis/
 COPY controllers/ controllers/
 COPY handlers/ handlers/
 COPY helpers/ helpers/
+COPY internal/ internal/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags "-X main.version=${VERSION}" -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.1
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "0.0.1")
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -50,6 +50,7 @@ endif
 IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.35
+LDFLAGS ?= -ldflags "-X main.version=$(VERSION)"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -113,7 +114,7 @@ test: manifests generate fmt vet lint envtest ## Run tests.
 
 .PHONY: build
 build: manifests generate fmt vet lint ## Build manager binary.
-	go build -o bin/manager main.go
+	go build $(LDFLAGS) -o bin/manager main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
@@ -124,7 +125,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build --build-arg VERSION=$(VERSION) -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -139,7 +140,7 @@ docker-push: ## Push docker image with the manager.
 PLATFORMS ?= linux/arm64,linux/amd64
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for cross-platform support
-	docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} .
+	docker buildx build --push --platform=$(PLATFORMS) --build-arg VERSION=$(VERSION) --tag ${IMG} .
 
 ##@ Deployment
 
@@ -205,9 +206,8 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 .PHONY: envtest
-envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
-$(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+envtest: ## Download envtest-setup locally if necessary.
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.

--- a/controllers/job/backup_controller.go
+++ b/controllers/job/backup_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/szeber/kube-stager/helpers"
 	"github.com/szeber/kube-stager/helpers/labels"
 	"github.com/szeber/kube-stager/helpers/pod"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,6 +74,7 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	result, err := r.doReconcile(ctx, req)
 
 	if err != nil {
+		appmetrics.Errors.WithLabelValues("backup", "false").Inc()
 		sentry.CaptureException(err)
 	}
 
@@ -140,11 +142,16 @@ func (r *BackupReconciler) ensureJobsAreUpToDate(ctx context.Context, job *jobv1
 
 	if len(services) == 0 {
 		logger.V(0).Info("No backups are required as there are no services with backups enabled in the site")
+		previousState := job.Status.State
 		job.Status.State = jobv1.Complete
 		_ = r.updateJobStartedAtIfNeeded(job, r.Now())
 		if job.Status.JobFinishedAt == nil {
 			t := metav1.NewTime(r.Now())
 			job.Status.JobFinishedAt = &t
+		}
+		if previousState != jobv1.Complete {
+			appmetrics.JobCompletions.WithLabelValues("backup", "success").Inc()
+			appmetrics.BackupCompletions.WithLabelValues(job.Namespace, string(job.Spec.BackupType)).Inc()
 		}
 
 		return true, nil
@@ -163,11 +170,19 @@ func (r *BackupReconciler) ensureJobsAreUpToDate(ctx context.Context, job *jobv1
 	}
 
 	if job.Status.State != jobv1.Failed && allServicesFinished {
+		previousState := job.Status.State
 		job.Status.State = jobv1.Complete
 		if lastFinishedAt != nil {
 			job.Status.JobFinishedAt = &metav1.Time{Time: *lastFinishedAt}
 		}
 		isChanged = true
+		if previousState != jobv1.Complete {
+			appmetrics.JobCompletions.WithLabelValues("backup", "success").Inc()
+			appmetrics.BackupCompletions.WithLabelValues(job.Namespace, string(job.Spec.BackupType)).Inc()
+			if job.Status.JobStartedAt != nil && job.Status.JobFinishedAt != nil {
+				appmetrics.JobDuration.WithLabelValues("backup").Observe(job.Status.JobFinishedAt.Sub(job.Status.JobStartedAt.Time).Seconds())
+			}
+		}
 	}
 
 	return isChanged, nil
@@ -192,7 +207,10 @@ func (r *BackupReconciler) processServiceInJob(
 		if serviceStatus.State.IsFinal() {
 			switch serviceStatus.State {
 			case jobv1.Failed:
-				job.Status.State = jobv1.Failed
+				if job.Status.State != jobv1.Failed {
+					job.Status.State = jobv1.Failed
+					appmetrics.JobCompletions.WithLabelValues("backup", "failure").Inc()
+				}
 				isChanged = true
 			case jobv1.Complete:
 				if lastFinishedAt == nil || lastFinishedAt.Before(serviceStatus.JobFinishedAt.Time) {
@@ -248,7 +266,10 @@ func (r *BackupReconciler) processServiceInJob(
 
 				if v.Type == batchv1.JobFailed && v.Status == corev1.ConditionTrue {
 					logger.V(0).Info("Job failed", "status", v.Message, "reason", v.Reason)
-					job.Status.State = jobv1.Failed
+					if job.Status.State != jobv1.Failed {
+						job.Status.State = jobv1.Failed
+						appmetrics.JobCompletions.WithLabelValues("backup", "failure").Inc()
+					}
 					serviceStatus.State = jobv1.Failed
 					isChanged = true
 					break

--- a/controllers/job/backup_controller_test.go
+++ b/controllers/job/backup_controller_test.go
@@ -10,6 +10,8 @@ import (
 	configv1 "github.com/szeber/kube-stager/apis/config/v1"
 	jobv1 "github.com/szeber/kube-stager/apis/job/v1"
 	sitev1 "github.com/szeber/kube-stager/apis/site/v1"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
+	"github.com/szeber/kube-stager/internal/metricstest"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -175,6 +177,9 @@ var _ = Describe("BackupController", func() {
 		})
 
 		It("should transition to Complete", func() {
+			completionsBefore := metricstest.GetCounterValue(appmetrics.JobCompletions, "backup", "success")
+			backupCompletionsBefore := metricstest.GetCounterValue(appmetrics.BackupCompletions, ns, string(jobv1.BackupTypeManual))
+
 			backup := &jobv1.Backup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      backupName,
@@ -192,6 +197,12 @@ var _ = Describe("BackupController", func() {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(backup), fetched)).To(Succeed())
 				g.Expect(fetched.Status.State).To(Equal(jobv1.Complete))
 			}, timeout, interval).Should(Succeed())
+
+			completionsAfter := metricstest.GetCounterValue(appmetrics.JobCompletions, "backup", "success")
+			Expect(completionsAfter-completionsBefore).To(BeNumerically(">=", 1), "expected job_completions_total(backup, success) to be incremented")
+
+			backupCompletionsAfter := metricstest.GetCounterValue(appmetrics.BackupCompletions, ns, string(jobv1.BackupTypeManual))
+			Expect(backupCompletionsAfter-backupCompletionsBefore).To(BeNumerically(">=", 1), "expected backup_completions_total to be incremented")
 		})
 	})
 
@@ -438,6 +449,7 @@ var _ = Describe("BackupController", func() {
 		})
 
 		It("should transition to Failed when the batch Job reports a Failed condition", func() {
+			failuresBefore := metricstest.GetCounterValue(appmetrics.JobCompletions, "backup", "failure")
 			backup := &jobv1.Backup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      backupName,
@@ -498,6 +510,9 @@ var _ = Describe("BackupController", func() {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(backup), backup)).To(Succeed())
 				g.Expect(backup.Status.State).To(Equal(jobv1.Failed))
 			}, timeout, interval).Should(Succeed())
+
+			failuresAfter := metricstest.GetCounterValue(appmetrics.JobCompletions, "backup", "failure")
+			Expect(failuresAfter-failuresBefore).To(BeNumerically(">=", 1), "expected job_completions_total(backup, failure) to be incremented")
 		})
 	})
 

--- a/controllers/job/dbinitjob_controller.go
+++ b/controllers/job/dbinitjob_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/szeber/kube-stager/helpers"
 	labels "github.com/szeber/kube-stager/helpers/labels"
 	"github.com/szeber/kube-stager/helpers/pod"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,6 +68,7 @@ func (r *DbInitJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	result, err := r.doReconcile(ctx, req)
 
 	if err != nil {
+		appmetrics.Errors.WithLabelValues("dbinit", "false").Inc()
 		sentry.CaptureException(err)
 	}
 
@@ -156,12 +158,18 @@ func (r *DbInitJobReconciler) processRunningJob(job *jobv1.DbInitJob, ctx contex
 		if v.Type == batchv1.JobComplete && v.Status == corev1.ConditionTrue {
 			logger.V(1).Info("Job finished successfully")
 			job.Status.State = jobv1.Complete
+			appmetrics.JobCompletions.WithLabelValues("dbinit", "success").Inc()
+			if job.Status.DeadlineTimestamp != nil {
+				duration := time.Since(job.Status.DeadlineTimestamp.Add(-time.Duration(job.Spec.DeadlineSeconds) * time.Second))
+				appmetrics.JobDuration.WithLabelValues("dbinit").Observe(duration.Seconds())
+			}
 			return true, nil
 		}
 
 		if v.Type == batchv1.JobFailed && v.Status == corev1.ConditionTrue {
 			logger.V(0).Info("Job failed", "status", v.Message, "reason", v.Reason)
 			job.Status.State = jobv1.Failed
+			appmetrics.JobCompletions.WithLabelValues("dbinit", "failure").Inc()
 			return true, nil
 		}
 	}
@@ -169,6 +177,7 @@ func (r *DbInitJobReconciler) processRunningJob(job *jobv1.DbInitJob, ctx contex
 	if time.Now().After(job.Status.DeadlineTimestamp.Time) {
 		logger.V(0).Info("The job deadline has expired. Failing job.")
 		job.Status.State = jobv1.Failed
+		appmetrics.JobCompletions.WithLabelValues("dbinit", "failure").Inc()
 		return true, nil
 	}
 

--- a/controllers/job/dbinitjob_controller_test.go
+++ b/controllers/job/dbinitjob_controller_test.go
@@ -10,6 +10,8 @@ import (
 	configv1 "github.com/szeber/kube-stager/apis/config/v1"
 	jobv1 "github.com/szeber/kube-stager/apis/job/v1"
 	sitev1 "github.com/szeber/kube-stager/apis/site/v1"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
+	"github.com/szeber/kube-stager/internal/metricstest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -417,6 +419,7 @@ var _ = Describe("DbInitJobController", func() {
 		})
 
 		It("should transition to Failed after the deadline passes", func() {
+			failuresBefore := metricstest.GetCounterValue(appmetrics.JobCompletions, "dbinit", "failure")
 			job := &jobv1.DbInitJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      jobName,
@@ -462,6 +465,9 @@ var _ = Describe("DbInitJobController", func() {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), fetched)).To(Succeed())
 				g.Expect(fetched.Status.State).To(Equal(jobv1.Failed))
 			}, timeout, interval).Should(Succeed())
+
+			failuresAfter := metricstest.GetCounterValue(appmetrics.JobCompletions, "dbinit", "failure")
+			Expect(failuresAfter-failuresBefore).To(BeNumerically(">=", 1), "expected job_completions_total(dbinit, failure) to be incremented")
 		})
 	})
 

--- a/controllers/job/dbmigrationjob_controller.go
+++ b/controllers/job/dbmigrationjob_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/szeber/kube-stager/helpers"
 	"github.com/szeber/kube-stager/helpers/labels"
 	"github.com/szeber/kube-stager/helpers/pod"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,6 +64,7 @@ func (r *DbMigrationJobReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	result, err := r.doReconcile(ctx, req)
 
 	if err != nil {
+		appmetrics.Errors.WithLabelValues("dbmigration", "false").Inc()
 		sentry.CaptureException(err)
 	}
 
@@ -146,12 +148,18 @@ func (r *DbMigrationJobReconciler) processRunningJob(job *jobv1.DbMigrationJob, 
 		if v.Type == batchv1.JobComplete && v.Status == corev1.ConditionTrue {
 			logger.V(0).Info("Job finished successfully")
 			job.Status.State = jobv1.Complete
+			appmetrics.JobCompletions.WithLabelValues("dbmigration", "success").Inc()
+			if job.Status.DeadlineTimestamp != nil {
+				duration := time.Since(job.Status.DeadlineTimestamp.Add(-time.Duration(job.Spec.DeadlineSeconds) * time.Second))
+				appmetrics.JobDuration.WithLabelValues("dbmigration").Observe(duration.Seconds())
+			}
 			return true, nil
 		}
 
 		if v.Type == batchv1.JobFailed && v.Status == corev1.ConditionTrue {
 			logger.V(0).Info("Job failed", "status", v.Message, "reason", v.Reason)
 			job.Status.State = jobv1.Failed
+			appmetrics.JobCompletions.WithLabelValues("dbmigration", "failure").Inc()
 			return true, nil
 		}
 	}
@@ -159,6 +167,7 @@ func (r *DbMigrationJobReconciler) processRunningJob(job *jobv1.DbMigrationJob, 
 	if time.Now().After(job.Status.DeadlineTimestamp.Time) {
 		logger.V(0).Info("The job deadline has expired. Failing job.")
 		job.Status.State = jobv1.Failed
+		appmetrics.JobCompletions.WithLabelValues("dbmigration", "failure").Inc()
 		return true, nil
 	}
 

--- a/controllers/job/dbmigrationjob_controller_test.go
+++ b/controllers/job/dbmigrationjob_controller_test.go
@@ -10,6 +10,8 @@ import (
 	configv1 "github.com/szeber/kube-stager/apis/config/v1"
 	jobv1 "github.com/szeber/kube-stager/apis/job/v1"
 	sitev1 "github.com/szeber/kube-stager/apis/site/v1"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
+	"github.com/szeber/kube-stager/internal/metricstest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -293,6 +295,7 @@ var _ = Describe("DbMigrationJobController", func() {
 		})
 
 		It("should transition to Failed after the deadline passes", func() {
+			failuresBefore := metricstest.GetCounterValue(appmetrics.JobCompletions, "dbmigration", "failure")
 			job := &jobv1.DbMigrationJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      jobName,
@@ -334,6 +337,9 @@ var _ = Describe("DbMigrationJobController", func() {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), fetched)).To(Succeed())
 				g.Expect(fetched.Status.State).To(Equal(jobv1.Failed))
 			}, timeout, interval).Should(Succeed())
+
+			failuresAfter := metricstest.GetCounterValue(appmetrics.JobCompletions, "dbmigration", "failure")
+			Expect(failuresAfter-failuresBefore).To(BeNumerically(">=", 1), "expected job_completions_total(dbmigration, failure) to be incremented")
 		})
 	})
 

--- a/controllers/site/stagingsite_controller.go
+++ b/controllers/site/stagingsite_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/szeber/kube-stager/helpers/annotations"
 	errorhelpers "github.com/szeber/kube-stager/helpers/errors"
 	"github.com/szeber/kube-stager/helpers/indexes"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 	"hash/fnv"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -108,6 +109,15 @@ func (r *StagingSiteReconciler) doReconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	stateBeforeReconcile := site.Status.State
+	defer func() {
+		if stateBeforeReconcile != "" && site.Status.State != stateBeforeReconcile {
+			appmetrics.SiteStateTransitions.WithLabelValues(site.Namespace, string(stateBeforeReconcile), string(site.Status.State)).Inc()
+			if site.Status.State == sitev1.StateComplete && !site.CreationTimestamp.IsZero() {
+				appmetrics.SiteProvisioningDuration.WithLabelValues(site.Namespace).Observe(r.Now().Sub(site.CreationTimestamp.Time).Seconds())
+			}
+		}
+	}()
 	logger.V(0).Info("Fetched staging site " + site.Name)
 
 	if site.DeletionTimestamp != nil {
@@ -131,8 +141,11 @@ func (r *StagingSiteReconciler) doReconcile(ctx context.Context, req ctrl.Reques
 	r.resetStatusErrors(site)
 
 	if site.Status.DeleteAt != nil && site.Status.DeleteAt.Time.Before(r.Now()) {
-		err := r.Delete(ctx, site)
-		return ctrl.Result{}, err
+		if err := r.Delete(ctx, site); err != nil {
+			return ctrl.Result{}, err
+		}
+		appmetrics.SiteAutoDeleted.WithLabelValues(site.Namespace).Inc()
+		return ctrl.Result{}, nil
 	}
 
 	isSiteChanged := false
@@ -388,6 +401,9 @@ func (r *StagingSiteReconciler) ensureStatusIsUpToDate(site *sitev1.StagingSite,
 	expectedEnabled := site.Spec.Enabled && (site.Status.DisableAt == nil || site.Status.DisableAt.After(r.Now()))
 
 	if site.Status.Enabled != expectedEnabled {
+		if site.Status.Enabled && !expectedEnabled && site.Spec.Enabled {
+			appmetrics.SiteAutoDisabled.WithLabelValues(site.Namespace).Inc()
+		}
 		site.Status.Enabled = expectedEnabled
 		site.Status.State = sitev1.StatePending
 		isChanged = true
@@ -705,12 +721,17 @@ func (r *StagingSiteReconciler) SaveStatusUpdatesIfObjectChanged(
 		if errors.As(err, &controllerError) {
 			if controllerError.IsFinal() {
 				log.FromContext(ctx).Error(controllerError, "Received final controller error. Failing site")
+				appmetrics.Errors.WithLabelValues("stagingsite", "true").Inc()
 				site.Status.State = sitev1.StateFailed
 				site.Status.ErrorMessage = err.Error()
 				isChanged = true
 				result = ctrl.Result{}
 				err = nil
+			} else {
+				appmetrics.Errors.WithLabelValues("stagingsite", "false").Inc()
 			}
+		} else {
+			appmetrics.Errors.WithLabelValues("stagingsite", "false").Inc()
 		}
 		if site.Status.State == sitev1.StateFailed && !isChanged {
 			isChanged = true

--- a/controllers/site/stagingsite_controller_test.go
+++ b/controllers/site/stagingsite_controller_test.go
@@ -28,6 +28,8 @@ import (
 	taskv1 "github.com/szeber/kube-stager/apis/task/v1"
 	"github.com/szeber/kube-stager/helpers"
 	"github.com/szeber/kube-stager/helpers/annotations"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
+	"github.com/szeber/kube-stager/internal/metricstest"
 	"github.com/szeber/kube-stager/internal/testutil"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -439,6 +441,8 @@ var _ = Describe("StagingSite controller", func() {
 		})
 
 		It("should eventually reach Complete state", func() {
+			transitionsBefore := metricstest.GetCounterValue(appmetrics.SiteStateTransitions, ns, string(sitev1.StatePending), string(sitev1.StateComplete))
+
 			fetched := &sitev1.StagingSite{}
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: siteName, Namespace: ns}, fetched)).To(Succeed())
@@ -451,6 +455,9 @@ var _ = Describe("StagingSite controller", func() {
 			Expect(fetched.Status.ConfigsAreCreated).To(BeTrue())
 			Expect(fetched.Status.WorkloadsAreCreated).To(BeTrue())
 			Expect(fetched.Status.NetworkingObjectsAreCreated).To(BeTrue())
+
+			transitionsAfter := metricstest.GetCounterValue(appmetrics.SiteStateTransitions, ns, string(sitev1.StatePending), string(sitev1.StateComplete))
+			Expect(transitionsAfter-transitionsBefore).To(BeNumerically(">=", 1), "expected site_state_transitions_total(Pending->Complete) to be incremented")
 		})
 	})
 
@@ -523,6 +530,7 @@ var _ = Describe("StagingSite controller", func() {
 				g.Expect(fetched.Status.Enabled).To(BeTrue())
 			}, timeout, interval).Should(Succeed())
 
+			disableBefore := metricstest.GetCounterValue(appmetrics.SiteAutoDisabled, ns)
 			testClock.SetNow(fetched.Status.DisableAt.Add(1 * time.Minute))
 
 			// envtest won't re-enqueue after the deadline passes, so write an annotation to force reconciliation
@@ -539,6 +547,9 @@ var _ = Describe("StagingSite controller", func() {
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: siteName, Namespace: ns}, fetched)).To(Succeed())
 				g.Expect(fetched.Status.Enabled).To(BeFalse())
 			}, timeout, interval).Should(Succeed())
+
+			disableAfter := metricstest.GetCounterValue(appmetrics.SiteAutoDisabled, ns)
+			Expect(disableAfter-disableBefore).To(BeNumerically(">=", 1), "expected site_auto_disabled_total to be incremented")
 		})
 	})
 
@@ -576,6 +587,7 @@ var _ = Describe("StagingSite controller", func() {
 				g.Expect(fetched.Status.DeleteAt).NotTo(BeNil())
 			}, timeout, interval).Should(Succeed())
 
+			deleteBefore := metricstest.GetCounterValue(appmetrics.SiteAutoDeleted, ns)
 			testClock.SetNow(fetched.Status.DeleteAt.Add(1 * time.Minute))
 
 			// envtest won't re-enqueue after the deadline passes, so write an annotation to force reconciliation
@@ -593,6 +605,9 @@ var _ = Describe("StagingSite controller", func() {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(client.IgnoreNotFound(err)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
+
+			deleteAfter := metricstest.GetCounterValue(appmetrics.SiteAutoDeleted, ns)
+			Expect(deleteAfter-deleteBefore).To(BeNumerically(">=", 1), "expected site_auto_deleted_total to be incremented")
 		})
 	})
 

--- a/controllers/task/mongodatabase_controller.go
+++ b/controllers/task/mongodatabase_controller.go
@@ -24,6 +24,7 @@ import (
 	controller "github.com/szeber/kube-stager/controllers"
 	"github.com/szeber/kube-stager/handlers/database"
 	"github.com/szeber/kube-stager/helpers"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -50,6 +51,7 @@ func (r *MongoDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	result, err := r.doReconcile(ctx, req)
 
 	if err != nil {
+		appmetrics.Errors.WithLabelValues("mongo", "false").Inc()
 		sentry.CaptureException(err)
 	}
 

--- a/controllers/task/mysqldatabase_controller.go
+++ b/controllers/task/mysqldatabase_controller.go
@@ -24,6 +24,7 @@ import (
 	controller "github.com/szeber/kube-stager/controllers"
 	"github.com/szeber/kube-stager/handlers/database"
 	"github.com/szeber/kube-stager/helpers"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,6 +52,7 @@ func (r *MysqlDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	result, err := r.doReconcile(ctx, req)
 
 	if err != nil {
+		appmetrics.Errors.WithLabelValues("mysql", "false").Inc()
 		sentry.CaptureException(err)
 	}
 

--- a/controllers/task/redisdatabase_controller.go
+++ b/controllers/task/redisdatabase_controller.go
@@ -22,6 +22,7 @@ import (
 	configv1 "github.com/szeber/kube-stager/apis/config/v1"
 	controller "github.com/szeber/kube-stager/controllers"
 	"github.com/szeber/kube-stager/handlers/database"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -50,6 +51,7 @@ func (r *RedisDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	result, err := r.doReconcile(ctx, req)
 
 	if err != nil {
+		appmetrics.Errors.WithLabelValues("redis", "false").Inc()
 		sentry.CaptureException(err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/grokify/mogo v0.73.4
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
+	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/sethvargo/go-password v0.3.1
 	go.mongodb.org/mongo-driver v1.17.9
 	k8s.io/api v0.35.2
@@ -55,14 +57,13 @@ require (
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.4 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect

--- a/handlers/database/mongo_handler.go
+++ b/handlers/database/mongo_handler.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
 	configv1 "github.com/szeber/kube-stager/apis/config/v1"
 	taskv1 "github.com/szeber/kube-stager/apis/task/v1"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -26,6 +28,9 @@ func ReconcileMongoDatabase(database *taskv1.MongoDatabase, config configv1.Mong
 	bool,
 	error,
 ) {
+	timer := prometheus.NewTimer(appmetrics.DatabaseOperationDuration.WithLabelValues("mongo", "reconcile"))
+	defer timer.ObserveDuration()
+
 	client, ctx, cancel, err := getMongoConnection(config, logger)
 
 	if cancel != nil {
@@ -33,6 +38,7 @@ func ReconcileMongoDatabase(database *taskv1.MongoDatabase, config configv1.Mong
 	}
 
 	if err != nil {
+		appmetrics.DatabaseOperations.WithLabelValues("mongo", "reconcile", "error").Inc()
 		return false, err
 	}
 
@@ -46,8 +52,11 @@ func ReconcileMongoDatabase(database *taskv1.MongoDatabase, config configv1.Mong
 	}
 
 	if err := task.reconcileTask(); err != nil {
+		appmetrics.DatabaseOperations.WithLabelValues("mongo", "reconcile", "error").Inc()
 		return false, err
 	}
+
+	appmetrics.DatabaseOperations.WithLabelValues("mongo", "reconcile", "success").Inc()
 
 	isChanged := false
 	if database.Status.State != taskv1.Complete {
@@ -59,6 +68,9 @@ func ReconcileMongoDatabase(database *taskv1.MongoDatabase, config configv1.Mong
 }
 
 func DeleteMongoDatabase(database *taskv1.MongoDatabase, config configv1.MongoConfig, logger logr.Logger) error {
+	timer := prometheus.NewTimer(appmetrics.DatabaseOperationDuration.WithLabelValues("mongo", "delete"))
+	defer timer.ObserveDuration()
+
 	client, ctx, cancel, err := getMongoConnection(config, logger)
 
 	if cancel != nil {
@@ -66,6 +78,7 @@ func DeleteMongoDatabase(database *taskv1.MongoDatabase, config configv1.MongoCo
 	}
 
 	if err != nil {
+		appmetrics.DatabaseOperations.WithLabelValues("mongo", "delete", "error").Inc()
 		return err
 	}
 
@@ -78,7 +91,13 @@ func DeleteMongoDatabase(database *taskv1.MongoDatabase, config configv1.MongoCo
 		database:   database.Spec.DatabaseName,
 	}
 
-	return task.deleteTask()
+	if err := task.deleteTask(); err != nil {
+		appmetrics.DatabaseOperations.WithLabelValues("mongo", "delete", "error").Inc()
+		return err
+	}
+
+	appmetrics.DatabaseOperations.WithLabelValues("mongo", "delete", "success").Inc()
+	return nil
 }
 
 func getMongoConnection(config configv1.MongoConfig, logger logr.Logger) (

--- a/handlers/database/mysql_handler.go
+++ b/handlers/database/mysql_handler.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"github.com/go-logr/logr"
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/prometheus/client_golang/prometheus"
 	configv1 "github.com/szeber/kube-stager/apis/config/v1"
 	taskv1 "github.com/szeber/kube-stager/apis/task/v1"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 )
 
 type mysqlReconcileTask struct {
@@ -28,6 +30,9 @@ func ReconcileMysqlDatabase(database *taskv1.MysqlDatabase, config configv1.Mysq
 	bool,
 	error,
 ) {
+	timer := prometheus.NewTimer(appmetrics.DatabaseOperationDuration.WithLabelValues("mysql", "reconcile"))
+	defer timer.ObserveDuration()
+
 	logger.Info("Connecting to database " + config.Name)
 
 	dataSourceName := fmt.Sprintf(
@@ -41,6 +46,7 @@ func ReconcileMysqlDatabase(database *taskv1.MysqlDatabase, config configv1.Mysq
 	connection, err := sql.Open("mysql", dataSourceName)
 
 	if err != nil {
+		appmetrics.DatabaseOperations.WithLabelValues("mysql", "reconcile", "error").Inc()
 		return false, err
 	}
 
@@ -59,8 +65,11 @@ func ReconcileMysqlDatabase(database *taskv1.MysqlDatabase, config configv1.Mysq
 	}
 
 	if err := task.reconcileTask(); err != nil {
+		appmetrics.DatabaseOperations.WithLabelValues("mysql", "reconcile", "error").Inc()
 		return false, err
 	}
+
+	appmetrics.DatabaseOperations.WithLabelValues("mysql", "reconcile", "success").Inc()
 
 	isChanged := false
 	if database.Status.State != taskv1.Complete {
@@ -72,6 +81,9 @@ func ReconcileMysqlDatabase(database *taskv1.MysqlDatabase, config configv1.Mysq
 }
 
 func DeleteMysqlDatabase(database *taskv1.MysqlDatabase, config configv1.MysqlConfig, logger logr.Logger) error {
+	timer := prometheus.NewTimer(appmetrics.DatabaseOperationDuration.WithLabelValues("mysql", "delete"))
+	defer timer.ObserveDuration()
+
 	logger.Info("Connecting to database " + config.Name)
 
 	dataSourceName := fmt.Sprintf(
@@ -85,6 +97,7 @@ func DeleteMysqlDatabase(database *taskv1.MysqlDatabase, config configv1.MysqlCo
 	connection, err := sql.Open("mysql", dataSourceName)
 
 	if err != nil {
+		appmetrics.DatabaseOperations.WithLabelValues("mysql", "delete", "error").Inc()
 		return err
 	}
 
@@ -100,7 +113,13 @@ func DeleteMysqlDatabase(database *taskv1.MysqlDatabase, config configv1.MysqlCo
 		database:   database.Spec.DatabaseName,
 	}
 
-	return task.deleteTask()
+	if err := task.deleteTask(); err != nil {
+		appmetrics.DatabaseOperations.WithLabelValues("mysql", "delete", "error").Inc()
+		return err
+	}
+
+	appmetrics.DatabaseOperations.WithLabelValues("mysql", "delete", "success").Inc()
+	return nil
 }
 
 func (r *mysqlReconcileTask) reconcileTask() error {

--- a/handlers/database/redis_handler.go
+++ b/handlers/database/redis_handler.go
@@ -5,14 +5,19 @@ import (
 	"fmt"
 	"github.com/go-logr/logr"
 	"github.com/go-redis/redis"
+	"github.com/prometheus/client_golang/prometheus"
 	configv1 "github.com/szeber/kube-stager/apis/config/v1"
 	taskv1 "github.com/szeber/kube-stager/apis/task/v1"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 )
 
 func ReconcileRedis(database *taskv1.RedisDatabase, config configv1.RedisConfig, logger logr.Logger) (bool, error) {
 	if database.Status.State == taskv1.Complete {
 		return false, nil
 	}
+
+	timer := prometheus.NewTimer(appmetrics.DatabaseOperationDuration.WithLabelValues("redis", "reconcile"))
+	defer timer.ObserveDuration()
 
 	var tlsConfig *tls.Config
 
@@ -38,8 +43,11 @@ func ReconcileRedis(database *taskv1.RedisDatabase, config configv1.RedisConfig,
 	foo := client.FlushDB()
 
 	if err := foo.Err(); err != nil {
+		appmetrics.DatabaseOperations.WithLabelValues("redis", "reconcile", "error").Inc()
 		return false, err
 	}
+
+	appmetrics.DatabaseOperations.WithLabelValues("redis", "reconcile", "success").Inc()
 
 	database.Status.State = taskv1.Complete
 

--- a/handlers/webhook/backup_create_or_update.go
+++ b/handlers/webhook/backup_create_or_update.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	jobv1 "github.com/szeber/kube-stager/apis/job/v1"
 	sitev1 "github.com/szeber/kube-stager/apis/site/v1"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"net/http"
@@ -41,6 +42,7 @@ func (r *BackupCreateOrUpdateHandler) Handle(ctx context.Context, req admission.
 	}
 
 	if err != nil {
+		appmetrics.WebhookDenied.WithLabelValues("backup", "site_not_found").Inc()
 		return admission.Denied(
 			fmt.Sprintf(
 				"Staging site with name %s not found in namespace %s",

--- a/handlers/webhook/backup_create_or_update_test.go
+++ b/handlers/webhook/backup_create_or_update_test.go
@@ -11,6 +11,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	jobv1 "github.com/szeber/kube-stager/apis/job/v1"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
+	"github.com/szeber/kube-stager/internal/metricstest"
 	"github.com/szeber/kube-stager/internal/testutil"
 )
 
@@ -67,6 +69,7 @@ func TestBackupCreateOrUpdateHandler_SiteNotFound(t *testing.T) {
 		Decoder: admission.NewDecoder(testutil.NewTestScheme()),
 	}
 
+	before := metricstest.GetCounterValue(appmetrics.WebhookDenied, "backup", "site_not_found")
 	resp := handler.Handle(context.Background(), makeBackupAdmissionRequest(t, backup))
 
 	if resp.Allowed {
@@ -74,6 +77,10 @@ func TestBackupCreateOrUpdateHandler_SiteNotFound(t *testing.T) {
 	}
 	if resp.Result == nil || resp.Result.Code != http.StatusForbidden {
 		t.Errorf("expected Forbidden (403), got: %v", resp.Result)
+	}
+	after := metricstest.GetCounterValue(appmetrics.WebhookDenied, "backup", "site_not_found")
+	if after-before != 1 {
+		t.Errorf("expected webhook_denied_total(backup, site_not_found) to increment by 1, got delta %v", after-before)
 	}
 }
 

--- a/handlers/webhook/mongoconfig_delete.go
+++ b/handlers/webhook/mongoconfig_delete.go
@@ -7,6 +7,7 @@ import (
 	sitev1 "github.com/szeber/kube-stager/apis/site/v1"
 	"github.com/szeber/kube-stager/helpers/indexes"
 	"github.com/szeber/kube-stager/helpers/labels"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -43,6 +44,7 @@ func (r *MongoConfigDeleteHandler) Handle(ctx context.Context, req admission.Req
 				siteNames,
 			),
 		)
+		appmetrics.WebhookDenied.WithLabelValues("mongoconfig_delete", "resource_in_use").Inc()
 		return admission.Denied(fmt.Sprintf("There are sites using this environment: %v", siteNames))
 	}
 
@@ -68,6 +70,7 @@ func (r *MongoConfigDeleteHandler) Handle(ctx context.Context, req admission.Req
 				serviceNames,
 			),
 		)
+		appmetrics.WebhookDenied.WithLabelValues("mongoconfig_delete", "resource_in_use").Inc()
 		return admission.Denied(fmt.Sprintf("There are services using this environment as a default: %v", serviceNames))
 	}
 

--- a/handlers/webhook/mongoconfig_delete_test.go
+++ b/handlers/webhook/mongoconfig_delete_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/szeber/kube-stager/helpers/labels"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
+	"github.com/szeber/kube-stager/internal/metricstest"
 	"github.com/szeber/kube-stager/internal/testutil"
 )
 
@@ -26,6 +28,7 @@ func TestMongoConfigDeleteHandler_SitesUsingEnvironment(t *testing.T) {
 		Client: testutil.NewFakeClient(site),
 	}
 
+	before := metricstest.GetCounterValue(appmetrics.WebhookDenied, "mongoconfig_delete", "resource_in_use")
 	resp := handler.Handle(context.Background(), makeDeleteAdmissionRequest(ns, envName))
 
 	if resp.Allowed {
@@ -33,6 +36,10 @@ func TestMongoConfigDeleteHandler_SitesUsingEnvironment(t *testing.T) {
 	}
 	if resp.Result == nil || resp.Result.Code != http.StatusForbidden {
 		t.Errorf("expected Forbidden (403), got: %v", resp.Result)
+	}
+	after := metricstest.GetCounterValue(appmetrics.WebhookDenied, "mongoconfig_delete", "resource_in_use")
+	if after-before != 1 {
+		t.Errorf("expected webhook_denied_total to increment by 1, got delta %v", after-before)
 	}
 }
 

--- a/handlers/webhook/mysqlconfig_delete.go
+++ b/handlers/webhook/mysqlconfig_delete.go
@@ -7,6 +7,7 @@ import (
 	sitev1 "github.com/szeber/kube-stager/apis/site/v1"
 	"github.com/szeber/kube-stager/helpers/indexes"
 	"github.com/szeber/kube-stager/helpers/labels"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -43,6 +44,7 @@ func (r *MysqlConfigDeleteHandler) Handle(ctx context.Context, req admission.Req
 				siteNames,
 			),
 		)
+		appmetrics.WebhookDenied.WithLabelValues("mysqlconfig_delete", "resource_in_use").Inc()
 		return admission.Denied(fmt.Sprintf("There are sites using this environment: %v", siteNames))
 	}
 
@@ -68,6 +70,7 @@ func (r *MysqlConfigDeleteHandler) Handle(ctx context.Context, req admission.Req
 				serviceNames,
 			),
 		)
+		appmetrics.WebhookDenied.WithLabelValues("mysqlconfig_delete", "resource_in_use").Inc()
 		return admission.Denied(fmt.Sprintf("There are services using this environment as a default: %v", serviceNames))
 	}
 

--- a/handlers/webhook/mysqlconfig_delete_test.go
+++ b/handlers/webhook/mysqlconfig_delete_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/szeber/kube-stager/helpers/labels"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
+	"github.com/szeber/kube-stager/internal/metricstest"
 	"github.com/szeber/kube-stager/internal/testutil"
 )
 
@@ -26,6 +28,7 @@ func TestMysqlConfigDeleteHandler_SitesUsingEnvironment(t *testing.T) {
 		Client: testutil.NewFakeClient(site),
 	}
 
+	before := metricstest.GetCounterValue(appmetrics.WebhookDenied, "mysqlconfig_delete", "resource_in_use")
 	resp := handler.Handle(context.Background(), makeDeleteAdmissionRequest(ns, envName))
 
 	if resp.Allowed {
@@ -33,6 +36,10 @@ func TestMysqlConfigDeleteHandler_SitesUsingEnvironment(t *testing.T) {
 	}
 	if resp.Result == nil || resp.Result.Code != http.StatusForbidden {
 		t.Errorf("expected Forbidden (403), got: %v", resp.Result)
+	}
+	after := metricstest.GetCounterValue(appmetrics.WebhookDenied, "mysqlconfig_delete", "resource_in_use")
+	if after-before != 1 {
+		t.Errorf("expected webhook_denied_total to increment by 1, got delta %v", after-before)
 	}
 }
 

--- a/handlers/webhook/redisconfig_delete.go
+++ b/handlers/webhook/redisconfig_delete.go
@@ -7,6 +7,7 @@ import (
 	sitev1 "github.com/szeber/kube-stager/apis/site/v1"
 	"github.com/szeber/kube-stager/helpers/indexes"
 	"github.com/szeber/kube-stager/helpers/labels"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -43,6 +44,7 @@ func (r *RedisConfigDeleteHandler) Handle(ctx context.Context, req admission.Req
 				siteNames,
 			),
 		)
+		appmetrics.WebhookDenied.WithLabelValues("redisconfig_delete", "resource_in_use").Inc()
 		return admission.Denied(fmt.Sprintf("There are sites using this environment: %v", siteNames))
 	}
 
@@ -68,6 +70,7 @@ func (r *RedisConfigDeleteHandler) Handle(ctx context.Context, req admission.Req
 				serviceNames,
 			),
 		)
+		appmetrics.WebhookDenied.WithLabelValues("redisconfig_delete", "resource_in_use").Inc()
 		return admission.Denied(fmt.Sprintf("There are services using this environment as a default: %v", serviceNames))
 	}
 

--- a/handlers/webhook/redisconfig_delete_test.go
+++ b/handlers/webhook/redisconfig_delete_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/szeber/kube-stager/helpers/labels"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
+	"github.com/szeber/kube-stager/internal/metricstest"
 	"github.com/szeber/kube-stager/internal/testutil"
 )
 
@@ -26,6 +28,7 @@ func TestRedisConfigDeleteHandler_SitesUsingEnvironment(t *testing.T) {
 		Client: testutil.NewFakeClient(site),
 	}
 
+	before := metricstest.GetCounterValue(appmetrics.WebhookDenied, "redisconfig_delete", "resource_in_use")
 	resp := handler.Handle(context.Background(), makeDeleteAdmissionRequest(ns, envName))
 
 	if resp.Allowed {
@@ -33,6 +36,10 @@ func TestRedisConfigDeleteHandler_SitesUsingEnvironment(t *testing.T) {
 	}
 	if resp.Result == nil || resp.Result.Code != http.StatusForbidden {
 		t.Errorf("expected Forbidden (403), got: %v", resp.Result)
+	}
+	after := metricstest.GetCounterValue(appmetrics.WebhookDenied, "redisconfig_delete", "resource_in_use")
+	if after-before != 1 {
+		t.Errorf("expected webhook_denied_total to increment by 1, got delta %v", after-before)
 	}
 }
 

--- a/handlers/webhook/serviceconfig_create_or_update.go
+++ b/handlers/webhook/serviceconfig_create_or_update.go
@@ -8,6 +8,7 @@ import (
 	"github.com/szeber/kube-stager/handlers/template"
 	"github.com/szeber/kube-stager/helpers"
 	errorshelpers "github.com/szeber/kube-stager/helpers/errors"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -68,6 +69,7 @@ func (r *ServiceConfigCreateOrUpdateHandler) Handle(ctx context.Context, req adm
 	if config.Spec.DefaultMongoEnvironment != "" {
 		logger.Info("Validating default mongo environment: " + config.Spec.DefaultMongoEnvironment)
 		if _, ok := templateHandler.GetMongo()[config.Spec.DefaultMongoEnvironment]; !ok {
+			appmetrics.WebhookDenied.WithLabelValues("serviceconfig", "invalid_environment").Inc()
 			return admission.Denied("Invalid mongo environment: " + config.Spec.DefaultMongoEnvironment)
 		}
 	}
@@ -75,6 +77,7 @@ func (r *ServiceConfigCreateOrUpdateHandler) Handle(ctx context.Context, req adm
 	if config.Spec.DefaultMysqlEnvironment != "" {
 		logger.Info("Validating default mysql environment: " + config.Spec.DefaultMysqlEnvironment)
 		if _, ok := templateHandler.GetMysql()[config.Spec.DefaultMysqlEnvironment]; !ok {
+			appmetrics.WebhookDenied.WithLabelValues("serviceconfig", "invalid_environment").Inc()
 			return admission.Denied("Invalid mysql environment: " + config.Spec.DefaultMysqlEnvironment)
 		}
 	}
@@ -82,6 +85,7 @@ func (r *ServiceConfigCreateOrUpdateHandler) Handle(ctx context.Context, req adm
 	if config.Spec.DefaultRedisEnvironment != "" {
 		logger.Info("Validating default redis environment: " + config.Spec.DefaultRedisEnvironment)
 		if _, ok := templateHandler.GetRedis()[config.Spec.DefaultRedisEnvironment]; !ok {
+			appmetrics.WebhookDenied.WithLabelValues("serviceconfig", "invalid_environment").Inc()
 			return admission.Denied("Invalid redis environment: " + config.Spec.DefaultRedisEnvironment)
 		}
 	}
@@ -89,6 +93,7 @@ func (r *ServiceConfigCreateOrUpdateHandler) Handle(ctx context.Context, req adm
 	logger.Info("Validating templates")
 	err = r.validateTemplates(*config, &templateHandler)
 	if errorshelpers.IsControllerError(err) {
+		appmetrics.WebhookDenied.WithLabelValues("serviceconfig", "template_validation_failed").Inc()
 		return admission.Denied(err.Error())
 	} else if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)

--- a/handlers/webhook/serviceconfig_delete.go
+++ b/handlers/webhook/serviceconfig_delete.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	sitev1 "github.com/szeber/kube-stager/apis/site/v1"
 	"github.com/szeber/kube-stager/helpers/labels"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -36,6 +37,7 @@ func (r *ServiceConfigDeleteHandler) Handle(ctx context.Context, req admission.R
 			siteNames = append(siteNames, v.Name)
 		}
 		logger.Info(fmt.Sprintf("Denying delete request, because there are sites using this service: %v", siteNames))
+		appmetrics.WebhookDenied.WithLabelValues("serviceconfig_delete", "resource_in_use").Inc()
 		return admission.Denied(fmt.Sprintf("There are sites using this service: %v", siteNames))
 	}
 

--- a/handlers/webhook/serviceconfig_delete_test.go
+++ b/handlers/webhook/serviceconfig_delete_test.go
@@ -11,6 +11,8 @@ import (
 
 	sitev1 "github.com/szeber/kube-stager/apis/site/v1"
 	"github.com/szeber/kube-stager/helpers/labels"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
+	"github.com/szeber/kube-stager/internal/metricstest"
 	"github.com/szeber/kube-stager/internal/testutil"
 )
 
@@ -51,6 +53,7 @@ func TestServiceConfigDeleteHandler_SitesUsingService(t *testing.T) {
 		Client: testutil.NewFakeClient(site),
 	}
 
+	before := metricstest.GetCounterValue(appmetrics.WebhookDenied, "serviceconfig_delete", "resource_in_use")
 	resp := handler.Handle(context.Background(), makeDeleteAdmissionRequest(ns, serviceName))
 
 	if resp.Allowed {
@@ -58,6 +61,10 @@ func TestServiceConfigDeleteHandler_SitesUsingService(t *testing.T) {
 	}
 	if resp.Result == nil || resp.Result.Code != http.StatusForbidden {
 		t.Errorf("expected Forbidden (403), got: %v", resp.Result)
+	}
+	after := metricstest.GetCounterValue(appmetrics.WebhookDenied, "serviceconfig_delete", "resource_in_use")
+	if after-before != 1 {
+		t.Errorf("expected webhook_denied_total to increment by 1, got delta %v", after-before)
 	}
 }
 

--- a/handlers/webhook/stagingsite.go
+++ b/handlers/webhook/stagingsite.go
@@ -8,6 +8,7 @@ import (
 	"github.com/szeber/kube-stager/helpers"
 	"github.com/szeber/kube-stager/helpers/kubernetes"
 	"github.com/szeber/kube-stager/helpers/labels"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -65,6 +66,7 @@ func (r *StagingsiteHandler) Handle(ctx context.Context, req admission.Request) 
 	}
 
 	if len(site.Spec.Services) == 0 {
+		appmetrics.WebhookDenied.WithLabelValues("stagingsite", "no_services_defined").Inc()
 		return admission.Denied("There are no services defined in the site")
 	}
 
@@ -77,6 +79,7 @@ func (r *StagingsiteHandler) Handle(ctx context.Context, req admission.Request) 
 		serviceNames = append(serviceNames, name)
 		config, ok := serviceConfigs[name]
 		if !ok {
+			appmetrics.WebhookDenied.WithLabelValues("stagingsite", "invalid_config").Inc()
 			return admission.Denied("The service config '" + name + "' doesn't exist")
 		}
 		if serviceSpec.ImageTag == "" {
@@ -96,6 +99,7 @@ func (r *StagingsiteHandler) Handle(ctx context.Context, req admission.Request) 
 		}
 		if serviceSpec.MongoEnvironment != "" {
 			if mongoEnvironments[serviceSpec.MongoEnvironment].Name == "" {
+				appmetrics.WebhookDenied.WithLabelValues("stagingsite", "invalid_environment").Inc()
 				return admission.Denied(
 					fmt.Sprintf(
 						"Invalid mongo environment '%s' in service '%s'",
@@ -109,6 +113,7 @@ func (r *StagingsiteHandler) Handle(ctx context.Context, req admission.Request) 
 		}
 		if serviceSpec.MysqlEnvironment != "" {
 			if mysqlEnvironments[serviceSpec.MysqlEnvironment].Name == "" {
+				appmetrics.WebhookDenied.WithLabelValues("stagingsite", "invalid_environment").Inc()
 				return admission.Denied(
 					fmt.Sprintf(
 						"Invalid mysql environment '%s' in service '%s'",
@@ -122,6 +127,7 @@ func (r *StagingsiteHandler) Handle(ctx context.Context, req admission.Request) 
 		}
 		if serviceSpec.RedisEnvironment != "" {
 			if redisEnvironments[serviceSpec.RedisEnvironment].Name == "" {
+				appmetrics.WebhookDenied.WithLabelValues("stagingsite", "invalid_environment").Inc()
 				return admission.Denied(
 					fmt.Sprintf(
 						"Invalid redis environment '%s' in service '%s'",

--- a/handlers/webhook/stagingsite_test.go
+++ b/handlers/webhook/stagingsite_test.go
@@ -12,6 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	sitev1 "github.com/szeber/kube-stager/apis/site/v1"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
+	"github.com/szeber/kube-stager/internal/metricstest"
 	"github.com/szeber/kube-stager/internal/testutil"
 )
 
@@ -70,6 +72,7 @@ func TestStagingsiteHandler_MissingServiceConfig(t *testing.T) {
 		},
 	})
 
+	before := metricstest.GetCounterValue(appmetrics.WebhookDenied, "stagingsite", "invalid_config")
 	resp := handler.Handle(context.Background(), makeSiteAdmissionRequest(t, site))
 
 	if resp.Allowed {
@@ -77,6 +80,10 @@ func TestStagingsiteHandler_MissingServiceConfig(t *testing.T) {
 	}
 	if resp.Result == nil || resp.Result.Code != http.StatusForbidden {
 		t.Errorf("expected Forbidden (403), got: %v", resp.Result)
+	}
+	after := metricstest.GetCounterValue(appmetrics.WebhookDenied, "stagingsite", "invalid_config")
+	if after-before != 1 {
+		t.Errorf("expected webhook_denied_total(stagingsite, invalid_config) to increment by 1, got delta %v", after-before)
 	}
 }
 
@@ -98,6 +105,7 @@ func TestStagingsiteHandler_InvalidMysqlEnvironment(t *testing.T) {
 		},
 	})
 
+	before := metricstest.GetCounterValue(appmetrics.WebhookDenied, "stagingsite", "invalid_environment")
 	resp := handler.Handle(context.Background(), makeSiteAdmissionRequest(t, site))
 
 	if resp.Allowed {
@@ -105,6 +113,10 @@ func TestStagingsiteHandler_InvalidMysqlEnvironment(t *testing.T) {
 	}
 	if resp.Result == nil || resp.Result.Code != http.StatusForbidden {
 		t.Errorf("expected Forbidden (403), got: %v", resp.Result)
+	}
+	after := metricstest.GetCounterValue(appmetrics.WebhookDenied, "stagingsite", "invalid_environment")
+	if after-before != 1 {
+		t.Errorf("expected webhook_denied_total(stagingsite, invalid_environment) to increment by 1, got delta %v", after-before)
 	}
 }
 
@@ -139,6 +151,7 @@ func TestStagingsiteHandler_EmptyServices(t *testing.T) {
 
 	site := testutil.NewTestStagingSite("mysite", ns, nil)
 
+	before := metricstest.GetCounterValue(appmetrics.WebhookDenied, "stagingsite", "no_services_defined")
 	resp := handler.Handle(context.Background(), makeSiteAdmissionRequest(t, site))
 
 	if resp.Allowed {
@@ -146,6 +159,10 @@ func TestStagingsiteHandler_EmptyServices(t *testing.T) {
 	}
 	if resp.Result == nil || resp.Result.Code != http.StatusForbidden {
 		t.Errorf("expected Forbidden (403), got: %v", resp.Result)
+	}
+	after := metricstest.GetCounterValue(appmetrics.WebhookDenied, "stagingsite", "no_services_defined")
+	if after-before != 1 {
+		t.Errorf("expected webhook_denied_total(stagingsite, no_services_defined) to increment by 1, got delta %v", after-before)
 	}
 }
 

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -1,0 +1,209 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	jobv1 "github.com/szeber/kube-stager/apis/job/v1"
+	sitev1 "github.com/szeber/kube-stager/apis/site/v1"
+	taskv1 "github.com/szeber/kube-stager/apis/task/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	stagingSitesDesc = prometheus.NewDesc(
+		"kube_stager_staging_sites",
+		"Current number of StagingSite resources by state and enabled status.",
+		[]string{"namespace", "state", "enabled"},
+		nil,
+	)
+	databasesDesc = prometheus.NewDesc(
+		"kube_stager_databases",
+		"Current number of database task resources by type and state.",
+		[]string{"namespace", "type", "state"},
+		nil,
+	)
+	jobsDesc = prometheus.NewDesc(
+		"kube_stager_jobs",
+		"Current number of job resources by kind and state.",
+		[]string{"namespace", "kind", "state"},
+		nil,
+	)
+)
+
+// ResourceCollector implements prometheus.Collector to provide resource inventory
+// gauges by reading from the informer cache on each scrape.
+type ResourceCollector struct {
+	reader client.Reader
+}
+
+// NewResourceCollector creates a new ResourceCollector.
+func NewResourceCollector(reader client.Reader) *ResourceCollector {
+	return &ResourceCollector{reader: reader}
+}
+
+func (c *ResourceCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- stagingSitesDesc
+	ch <- databasesDesc
+	ch <- jobsDesc
+}
+
+func (c *ResourceCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	c.collectStagingSites(ctx, ch)
+	c.collectDatabases(ctx, ch)
+	c.collectJobs(ctx, ch)
+}
+
+func (c *ResourceCollector) collectStagingSites(ctx context.Context, ch chan<- prometheus.Metric) {
+	var list sitev1.StagingSiteList
+	if err := c.reader.List(ctx, &list); err != nil {
+		ch <- prometheus.NewInvalidMetric(stagingSitesDesc, err)
+		return
+	}
+
+	type siteKey struct {
+		namespace string
+		state     string
+		enabled   string
+	}
+
+	counts := map[siteKey]float64{}
+	for _, site := range list.Items {
+		state := string(site.Status.State)
+		if state == "" {
+			state = string(sitev1.StatePending)
+		}
+		enabled := fmt.Sprintf("%t", site.Status.Enabled)
+		counts[siteKey{site.Namespace, state, enabled}]++
+	}
+
+	for key, count := range counts {
+		m, err := prometheus.NewConstMetric(stagingSitesDesc, prometheus.GaugeValue, count, key.namespace, key.state, key.enabled)
+		if err != nil {
+			ch <- prometheus.NewInvalidMetric(stagingSitesDesc, err)
+			return
+		}
+		ch <- m
+	}
+}
+
+func (c *ResourceCollector) collectDatabases(ctx context.Context, ch chan<- prometheus.Metric) {
+	type dbEntry struct {
+		namespace string
+		dbType    string
+		state     string
+	}
+
+	counts := map[dbEntry]float64{}
+
+	var mysqlList taskv1.MysqlDatabaseList
+	if err := c.reader.List(ctx, &mysqlList); err != nil {
+		ch <- prometheus.NewInvalidMetric(databasesDesc, err)
+		return
+	}
+	for _, db := range mysqlList.Items {
+		state := string(db.Status.State)
+		if state == "" {
+			state = string(taskv1.Pending)
+		}
+		counts[dbEntry{db.Namespace, "mysql", state}]++
+	}
+
+	var mongoList taskv1.MongoDatabaseList
+	if err := c.reader.List(ctx, &mongoList); err != nil {
+		ch <- prometheus.NewInvalidMetric(databasesDesc, err)
+		return
+	}
+	for _, db := range mongoList.Items {
+		state := string(db.Status.State)
+		if state == "" {
+			state = string(taskv1.Pending)
+		}
+		counts[dbEntry{db.Namespace, "mongo", state}]++
+	}
+
+	var redisList taskv1.RedisDatabaseList
+	if err := c.reader.List(ctx, &redisList); err != nil {
+		ch <- prometheus.NewInvalidMetric(databasesDesc, err)
+		return
+	}
+	for _, db := range redisList.Items {
+		state := string(db.Status.State)
+		if state == "" {
+			state = string(taskv1.Pending)
+		}
+		counts[dbEntry{db.Namespace, "redis", state}]++
+	}
+
+	for entry, count := range counts {
+		m, err := prometheus.NewConstMetric(databasesDesc, prometheus.GaugeValue, count, entry.namespace, entry.dbType, entry.state)
+		if err != nil {
+			ch <- prometheus.NewInvalidMetric(databasesDesc, err)
+			return
+		}
+		ch <- m
+	}
+}
+
+func (c *ResourceCollector) collectJobs(ctx context.Context, ch chan<- prometheus.Metric) {
+	type jobEntry struct {
+		namespace string
+		kind      string
+		state     string
+	}
+
+	counts := map[jobEntry]float64{}
+
+	var initList jobv1.DbInitJobList
+	if err := c.reader.List(ctx, &initList); err != nil {
+		ch <- prometheus.NewInvalidMetric(jobsDesc, err)
+		return
+	}
+	for _, j := range initList.Items {
+		state := string(j.Status.State)
+		if state == "" {
+			state = string(jobv1.Pending)
+		}
+		counts[jobEntry{j.Namespace, "dbinit", state}]++
+	}
+
+	var migrationList jobv1.DbMigrationJobList
+	if err := c.reader.List(ctx, &migrationList); err != nil {
+		ch <- prometheus.NewInvalidMetric(jobsDesc, err)
+		return
+	}
+	for _, j := range migrationList.Items {
+		state := string(j.Status.State)
+		if state == "" {
+			state = string(jobv1.Pending)
+		}
+		counts[jobEntry{j.Namespace, "dbmigration", state}]++
+	}
+
+	var backupList jobv1.BackupList
+	if err := c.reader.List(ctx, &backupList); err != nil {
+		ch <- prometheus.NewInvalidMetric(jobsDesc, err)
+		return
+	}
+	for _, j := range backupList.Items {
+		state := string(j.Status.State)
+		if state == "" {
+			state = string(jobv1.Pending)
+		}
+		counts[jobEntry{j.Namespace, "backup", state}]++
+	}
+
+	for entry, count := range counts {
+		m, err := prometheus.NewConstMetric(jobsDesc, prometheus.GaugeValue, count, entry.namespace, entry.kind, entry.state)
+		if err != nil {
+			ch <- prometheus.NewInvalidMetric(jobsDesc, err)
+			return
+		}
+		ch <- m
+	}
+}

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -1,0 +1,338 @@
+// Package metrics_test uses an external test package to avoid an import cycle:
+// metrics_test -> testutil -> testutil/mocks -> handlers/database -> metrics.
+// The scheme and fake client setup is duplicated here for this reason.
+package metrics_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	configv1 "github.com/szeber/kube-stager/apis/config/v1"
+	jobv1 "github.com/szeber/kube-stager/apis/job/v1"
+	sitev1 "github.com/szeber/kube-stager/apis/site/v1"
+	taskv1 "github.com/szeber/kube-stager/apis/task/v1"
+	"github.com/szeber/kube-stager/internal/metrics"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(configv1.AddToScheme(s))
+	utilruntime.Must(jobv1.AddToScheme(s))
+	utilruntime.Must(sitev1.AddToScheme(s))
+	utilruntime.Must(taskv1.AddToScheme(s))
+	return s
+}
+
+func newFakeClient(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		WithObjects(objs...).
+		WithStatusSubresource(
+			&sitev1.StagingSite{},
+			&taskv1.MysqlDatabase{},
+			&taskv1.MongoDatabase{},
+			&taskv1.RedisDatabase{},
+			&jobv1.DbInitJob{},
+			&jobv1.DbMigrationJob{},
+			&jobv1.Backup{},
+		).
+		Build()
+}
+
+func collectMetrics(t *testing.T, collector *metrics.ResourceCollector) map[string][]*dto.Metric {
+	t.Helper()
+
+	ch := make(chan prometheus.Metric, 100)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	result := map[string][]*dto.Metric{}
+	for m := range ch {
+		metric := &dto.Metric{}
+		if err := m.Write(metric); err != nil {
+			t.Fatalf("failed to write metric: %v", err)
+		}
+		desc := m.Desc().String()
+		for _, name := range []string{"kube_stager_staging_sites", "kube_stager_databases", "kube_stager_jobs"} {
+			if strings.Contains(desc, name) {
+				result[name] = append(result[name], metric)
+				break
+			}
+		}
+	}
+
+	return result
+}
+
+func getLabelValue(metric *dto.Metric, name string) string {
+	for _, lp := range metric.GetLabel() {
+		if lp.GetName() == name {
+			return lp.GetValue()
+		}
+	}
+	return ""
+}
+
+func TestCollector_Describe(t *testing.T) {
+	collector := metrics.NewResourceCollector(newFakeClient())
+	ch := make(chan *prometheus.Desc, 10)
+	go func() {
+		collector.Describe(ch)
+		close(ch)
+	}()
+
+	var descs []*prometheus.Desc
+	for d := range ch {
+		descs = append(descs, d)
+	}
+
+	if len(descs) != 3 {
+		t.Errorf("expected 3 descriptors, got %d", len(descs))
+	}
+}
+
+func TestCollector_EmptyCluster(t *testing.T) {
+	collector := metrics.NewResourceCollector(newFakeClient())
+	m := collectMetrics(t, collector)
+
+	if len(m["kube_stager_staging_sites"]) != 0 {
+		t.Errorf("expected 0 staging site metrics, got %d", len(m["kube_stager_staging_sites"]))
+	}
+	if len(m["kube_stager_databases"]) != 0 {
+		t.Errorf("expected 0 database metrics, got %d", len(m["kube_stager_databases"]))
+	}
+	if len(m["kube_stager_jobs"]) != 0 {
+		t.Errorf("expected 0 job metrics, got %d", len(m["kube_stager_jobs"]))
+	}
+}
+
+func TestCollector_StagingSites(t *testing.T) {
+	site1 := &sitev1.StagingSite{
+		ObjectMeta: metav1.ObjectMeta{Name: "site1", Namespace: "default"},
+		Status:     sitev1.StagingSiteStatus{State: sitev1.StateComplete, Enabled: true},
+	}
+	site2 := &sitev1.StagingSite{
+		ObjectMeta: metav1.ObjectMeta{Name: "site2", Namespace: "default"},
+		Status:     sitev1.StagingSiteStatus{State: sitev1.StateComplete, Enabled: true},
+	}
+	site3 := &sitev1.StagingSite{
+		ObjectMeta: metav1.ObjectMeta{Name: "site3", Namespace: "default"},
+		Status:     sitev1.StagingSiteStatus{State: sitev1.StateFailed, Enabled: false},
+	}
+	site4 := &sitev1.StagingSite{
+		ObjectMeta: metav1.ObjectMeta{Name: "site4", Namespace: "other-ns"},
+		Status:     sitev1.StagingSiteStatus{State: sitev1.StatePending, Enabled: true},
+	}
+
+	fakeClient := newFakeClient(site1, site2, site3, site4)
+	collector := metrics.NewResourceCollector(fakeClient)
+	m := collectMetrics(t, collector)
+
+	siteMetrics := m["kube_stager_staging_sites"]
+	if len(siteMetrics) != 3 {
+		t.Fatalf("expected 3 site metric series, got %d", len(siteMetrics))
+	}
+
+	found := map[string]float64{}
+	for _, metric := range siteMetrics {
+		key := getLabelValue(metric, "namespace") + "/" + getLabelValue(metric, "state") + "/" + getLabelValue(metric, "enabled")
+		found[key] = metric.GetGauge().GetValue()
+	}
+
+	if found["default/Complete/true"] != 2 {
+		t.Errorf("expected 2 Complete/true in default, got %v", found["default/Complete/true"])
+	}
+	if found["default/Failed/false"] != 1 {
+		t.Errorf("expected 1 Failed/false in default, got %v", found["default/Failed/false"])
+	}
+	if found["other-ns/Pending/true"] != 1 {
+		t.Errorf("expected 1 Pending/true in other-ns, got %v", found["other-ns/Pending/true"])
+	}
+}
+
+func TestCollector_Databases(t *testing.T) {
+	mysql1 := &taskv1.MysqlDatabase{
+		ObjectMeta: metav1.ObjectMeta{Name: "mysql1", Namespace: "default"},
+		Status:     taskv1.TaskStatus{State: taskv1.Complete},
+	}
+	mysql2 := &taskv1.MysqlDatabase{
+		ObjectMeta: metav1.ObjectMeta{Name: "mysql2", Namespace: "default"},
+		Status:     taskv1.TaskStatus{State: taskv1.Complete},
+	}
+	mongo1 := &taskv1.MongoDatabase{
+		ObjectMeta: metav1.ObjectMeta{Name: "mongo1", Namespace: "default"},
+		Status:     taskv1.TaskStatus{State: taskv1.Pending},
+	}
+	redis1 := &taskv1.RedisDatabase{
+		ObjectMeta: metav1.ObjectMeta{Name: "redis1", Namespace: "default"},
+		Status:     taskv1.TaskStatus{State: taskv1.Failed},
+	}
+
+	fakeClient := newFakeClient(mysql1, mysql2, mongo1, redis1)
+	collector := metrics.NewResourceCollector(fakeClient)
+	m := collectMetrics(t, collector)
+
+	dbMetrics := m["kube_stager_databases"]
+	if len(dbMetrics) != 3 {
+		t.Fatalf("expected 3 database metric series, got %d", len(dbMetrics))
+	}
+
+	found := map[string]float64{}
+	for _, metric := range dbMetrics {
+		key := getLabelValue(metric, "type") + "/" + getLabelValue(metric, "state")
+		found[key] = metric.GetGauge().GetValue()
+	}
+
+	if found["mysql/Complete"] != 2 {
+		t.Errorf("expected 2 mysql/Complete, got %v", found["mysql/Complete"])
+	}
+	if found["mongo/Pending"] != 1 {
+		t.Errorf("expected 1 mongo/Pending, got %v", found["mongo/Pending"])
+	}
+	if found["redis/Failed"] != 1 {
+		t.Errorf("expected 1 redis/Failed, got %v", found["redis/Failed"])
+	}
+}
+
+func TestCollector_Jobs(t *testing.T) {
+	initJob := &jobv1.DbInitJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "init1", Namespace: "default"},
+		Status:     jobv1.DbInitJobStatus{State: jobv1.Running},
+	}
+	migrationJob := &jobv1.DbMigrationJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "migration1", Namespace: "default"},
+		Status:     jobv1.DbMigrationJobStatus{State: jobv1.Complete},
+	}
+	backup1 := &jobv1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "backup1", Namespace: "default"},
+		Spec:       jobv1.BackupSpec{BackupType: jobv1.BackupTypeScheduled},
+		Status:     jobv1.BackupStatus{BackupStatusDetail: jobv1.BackupStatusDetail{State: jobv1.Complete}},
+	}
+	backup2 := &jobv1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "backup2", Namespace: "default"},
+		Spec:       jobv1.BackupSpec{BackupType: jobv1.BackupTypeManual},
+		Status:     jobv1.BackupStatus{BackupStatusDetail: jobv1.BackupStatusDetail{State: jobv1.Failed}},
+	}
+
+	fakeClient := newFakeClient(initJob, migrationJob, backup1, backup2)
+	collector := metrics.NewResourceCollector(fakeClient)
+	m := collectMetrics(t, collector)
+
+	jobMetrics := m["kube_stager_jobs"]
+
+	found := map[string]float64{}
+	for _, metric := range jobMetrics {
+		key := getLabelValue(metric, "kind") + "/" + getLabelValue(metric, "state")
+		found[key] = metric.GetGauge().GetValue()
+	}
+
+	if found["dbinit/Running"] != 1 {
+		t.Errorf("expected 1 dbinit/Running, got %v", found["dbinit/Running"])
+	}
+	if found["dbmigration/Complete"] != 1 {
+		t.Errorf("expected 1 dbmigration/Complete, got %v", found["dbmigration/Complete"])
+	}
+	if found["backup/Complete"] != 1 {
+		t.Errorf("expected 1 backup/Complete, got %v", found["backup/Complete"])
+	}
+	if found["backup/Failed"] != 1 {
+		t.Errorf("expected 1 backup/Failed, got %v", found["backup/Failed"])
+	}
+}
+
+func TestCollector_EmptyStateTreatedAsPending(t *testing.T) {
+	site := &sitev1.StagingSite{
+		ObjectMeta: metav1.ObjectMeta{Name: "site1", Namespace: "default"},
+	}
+
+	fakeClient := newFakeClient(site)
+	collector := metrics.NewResourceCollector(fakeClient)
+	m := collectMetrics(t, collector)
+
+	siteMetrics := m["kube_stager_staging_sites"]
+	if len(siteMetrics) != 1 {
+		t.Fatalf("expected 1 site metric, got %d", len(siteMetrics))
+	}
+
+	if getLabelValue(siteMetrics[0], "state") != "Pending" {
+		t.Errorf("expected empty state to be treated as Pending, got %s", getLabelValue(siteMetrics[0], "state"))
+	}
+}
+
+func TestCollector_MultipleNamespaces(t *testing.T) {
+	objs := []client.Object{
+		&sitev1.StagingSite{
+			ObjectMeta: metav1.ObjectMeta{Name: "site1", Namespace: "ns1"},
+			Status:     sitev1.StagingSiteStatus{State: sitev1.StateComplete, Enabled: true},
+		},
+		&sitev1.StagingSite{
+			ObjectMeta: metav1.ObjectMeta{Name: "site2", Namespace: "ns2"},
+			Status:     sitev1.StagingSiteStatus{State: sitev1.StateComplete, Enabled: true},
+		},
+	}
+
+	fakeClient := newFakeClient(objs...)
+	collector := metrics.NewResourceCollector(fakeClient)
+	m := collectMetrics(t, collector)
+
+	siteMetrics := m["kube_stager_staging_sites"]
+	if len(siteMetrics) != 2 {
+		t.Fatalf("expected 2 site metrics (one per namespace), got %d", len(siteMetrics))
+	}
+
+	namespaces := map[string]bool{}
+	for _, metric := range siteMetrics {
+		namespaces[getLabelValue(metric, "namespace")] = true
+	}
+
+	if !namespaces["ns1"] || !namespaces["ns2"] {
+		t.Errorf("expected metrics from both ns1 and ns2, got %v", namespaces)
+	}
+}
+
+// failingReader is a client.Reader that returns an error on every List call.
+type failingReader struct {
+	client.Reader
+}
+
+func (f failingReader) List(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+	return fmt.Errorf("injected list error")
+}
+
+func TestCollector_ListError_EmitsInvalidMetrics(t *testing.T) {
+	collector := metrics.NewResourceCollector(failingReader{})
+
+	ch := make(chan prometheus.Metric, 100)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	invalidCount := 0
+	for m := range ch {
+		dto := &dto.Metric{}
+		err := m.Write(dto)
+		if err != nil {
+			invalidCount++
+		}
+	}
+
+	// Each of the 3 collect functions (sites, databases, jobs) should emit one InvalidMetric
+	if invalidCount != 3 {
+		t.Errorf("expected 3 invalid metrics from failing reader, got %d", invalidCount)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,100 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	namespace = "kube_stager"
+)
+
+var factory = promauto.With(metrics.Registry)
+
+// BuildInfo exposes build metadata. Set once at startup with version and Go version.
+var BuildInfo = factory.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: namespace,
+	Name:      "build_info",
+	Help:      "Build information for the kube-stager operator. Always 1.",
+}, []string{"version", "go_version"})
+
+// SiteStateTransitions counts state transitions on StagingSite resources.
+var SiteStateTransitions = factory.NewCounterVec(prometheus.CounterOpts{
+	Namespace: namespace,
+	Name:      "site_state_transitions_total",
+	Help:      "Total number of StagingSite state transitions.",
+}, []string{"namespace", "from_state", "to_state"})
+
+// SiteAutoDisabled counts sites auto-disabled by timeout.
+var SiteAutoDisabled = factory.NewCounterVec(prometheus.CounterOpts{
+	Namespace: namespace,
+	Name:      "site_auto_disabled_total",
+	Help:      "Total number of StagingSites automatically disabled by timeout.",
+}, []string{"namespace"})
+
+// SiteAutoDeleted counts sites auto-deleted by timeout.
+var SiteAutoDeleted = factory.NewCounterVec(prometheus.CounterOpts{
+	Namespace: namespace,
+	Name:      "site_auto_deleted_total",
+	Help:      "Total number of StagingSites automatically deleted by timeout.",
+}, []string{"namespace"})
+
+// SiteProvisioningDuration tracks time from StagingSite creation to Complete state.
+var SiteProvisioningDuration = factory.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: namespace,
+	Name:      "site_provisioning_duration_seconds",
+	Help:      "Time from StagingSite creation to Complete state in seconds.",
+	Buckets:   []float64{10, 30, 60, 120, 300, 600, 1800, 3600},
+}, []string{"namespace"})
+
+// DatabaseOperations counts database provisioning operations.
+var DatabaseOperations = factory.NewCounterVec(prometheus.CounterOpts{
+	Namespace: namespace,
+	Name:      "database_operations_total",
+	Help:      "Total database provisioning operations.",
+}, []string{"type", "operation", "result"})
+
+// DatabaseOperationDuration tracks the duration of database operations.
+var DatabaseOperationDuration = factory.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: namespace,
+	Name:      "database_operation_duration_seconds",
+	Help:      "Duration of database operations in seconds.",
+	Buckets:   []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30},
+}, []string{"type", "operation"})
+
+// JobCompletions counts job completions by kind and result.
+var JobCompletions = factory.NewCounterVec(prometheus.CounterOpts{
+	Namespace: namespace,
+	Name:      "job_completions_total",
+	Help:      "Total job completions by kind and result.",
+}, []string{"kind", "result"})
+
+// JobDuration tracks job execution duration from start to completion.
+var JobDuration = factory.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: namespace,
+	Name:      "job_duration_seconds",
+	Help:      "Duration of jobs from start to completion in seconds.",
+	Buckets:   []float64{5, 15, 30, 60, 120, 300, 600, 1200},
+}, []string{"kind"})
+
+// BackupCompletions counts backup completions by type.
+var BackupCompletions = factory.NewCounterVec(prometheus.CounterOpts{
+	Namespace: namespace,
+	Name:      "backup_completions_total",
+	Help:      "Total backup completions by type.",
+}, []string{"namespace", "backup_type"})
+
+// Errors counts controller errors classified by finality.
+var Errors = factory.NewCounterVec(prometheus.CounterOpts{
+	Namespace: namespace,
+	Name:      "errors_total",
+	Help:      "Total controller errors classified by controller and finality.",
+}, []string{"controller", "final"})
+
+// WebhookDenied counts admission requests denied by validation logic.
+var WebhookDenied = factory.NewCounterVec(prometheus.CounterOpts{
+	Namespace: namespace,
+	Name:      "webhook_denied_total",
+	Help:      "Total admission requests denied by webhook validation logic.",
+}, []string{"webhook", "reason"})

--- a/internal/metricstest/helpers.go
+++ b/internal/metricstest/helpers.go
@@ -1,0 +1,19 @@
+// Package metricstest provides test helpers for asserting on Prometheus metric values.
+// This package is intentionally separate from internal/metrics to avoid shipping
+// prometheus/testutil in production binaries.
+package metricstest
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// GetCounterValue returns the current value of a counter metric with the given labels.
+// Returns 0 if the metric has not been observed yet.
+func GetCounterValue(counter *prometheus.CounterVec, labels ...string) float64 {
+	m, err := counter.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		return 0
+	}
+	return testutil.ToFloat64(m)
+}

--- a/main.go
+++ b/main.go
@@ -21,9 +21,11 @@ import (
 	"fmt"
 	"github.com/getsentry/sentry-go"
 	"os"
+	goruntime "runtime"
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -41,6 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	webhook2 "github.com/szeber/kube-stager/handlers/webhook"
+	appmetrics "github.com/szeber/kube-stager/internal/metrics"
 
 	configv1 "github.com/szeber/kube-stager/apis/config/v1"
 	controllerconfigv1 "github.com/szeber/kube-stager/apis/controller-config/v1"
@@ -56,6 +59,7 @@ import (
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+	version  = "dev"
 )
 
 func init() {
@@ -212,6 +216,9 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
+
+	appmetrics.BuildInfo.WithLabelValues(version, goruntime.Version()).Set(1)
+	metrics.Registry.MustRegister(appmetrics.NewResourceCollector(mgr.GetClient()))
 
 	if err = (&taskcontrollers.MysqlDatabaseReconciler{
 		Client: mgr.GetClient(),


### PR DESCRIPTION
Add 15 custom Prometheus metrics for operational observability:
- Resource inventory gauges (staging sites, databases, jobs by state) via a prometheus.Collector reading from the informer cache
- StagingSite lifecycle counters (state transitions, auto-disable, auto-delete) and provisioning duration histogram
- Database operation counters and duration histograms (mysql/mongo/redis)
- Job completion counters and duration histograms (dbinit/dbmigration/backup)
- Error counter with controller and finality classification
- Webhook denied counter with webhook and reason labels
- Build info gauge with version injection via ldflags

Also includes:
- Dockerfile fix: add COPY internal/ and VERSION build arg
- CI: add fetch-depth: 0 for git describe in both workflows
- Makefile: VERSION from git describe, LDFLAGS, docker build args, always-reinstall envtest target
- Test coverage: metric assertions in controller and webhook tests, collector unit tests including error paths
- Test helper in separate internal/metricstest package to keep prometheus/testutil out of production binary